### PR TITLE
change package type from wordpress-muplugin to wordpress-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ooksanen/acf-focuspoint",
     "description": "Adds a image focus field",
-    "type": "wordpress-muplugin",
+    "type": "wordpress-plugin",
     "license": "MIT",
     "funding": [
         {


### PR DESCRIPTION
Switch the composer package type to regular plugin instead of a must-use as this is not necessarily a must-use plugin otherwise it can't be easily disabled in the backend and other caveats, see: https://developer.wordpress.org/advanced-administration/plugins/mu-plugins/?cmdf=wordpress+must-use+plugins